### PR TITLE
Add --no-parent-folder flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Alternatively, instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` 
 | `--[no-]include-assets`   | None        | [Optional] Whether to include media assets. Defaults to `false` |
 | `--branch-name`   | `-b`        | [Optional] Which branch to download. Defaults to `main` |
 | `--[no-]fix`   | None        | [Optional] Whether to run `dart fix` on the downloaded code. Defaults to `false`. |
+| `--[no-]parent-folder`   | None        | [Optional] Whether to download code into a project-named sub-folder. If true, downloads all project files directly to the specified directory. Defaults to `false`. |
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Alternatively, instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` 
 | `--[no-]include-assets`   | None        | [Optional] Whether to include media assets. Defaults to `false` |
 | `--branch-name`   | `-b`        | [Optional] Which branch to download. Defaults to `main` |
 | `--[no-]fix`   | None        | [Optional] Whether to run `dart fix` on the downloaded code. Defaults to `false`. |
-| `--[no-]parent-folder`   | None        | [Optional] Whether to download code into a project-named sub-folder. If true, downloads all project files directly to the specified directory. Defaults to `false`. |
+| `--[no-]parent-folder`   | None        | [Optional] Whether to download code into a project-named sub-folder. If true, downloads all project files directly to the specified directory. Defaults to `true`. |
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ API access is available only to users with active subscriptions. Visit https://a
 
 ## Usage
 
-`flutterflow export-code --project <project id> --dest <output folder> --[no-]include-assets --token <token> --[no-]fix`
+`flutterflow export-code --project <project id> --dest <output folder> --[no-]include-assets --token <token> --[no-]fix --[no]-parent-folder`
 
 Alternatively, instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` environment variable.
 

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -250,7 +250,7 @@ Future _downloadAssets({
     try {
       final response = await client.get(Uri.parse(url));
       if (response.statusCode >= 200 && response.statusCode < 300) {
-        final filpushe = File(fileDest);
+        final file = File(fileDest);
         await file.writeAsBytes(response.bodyBytes);
       } else {
         stderr.write('Error downloading asset $path. This is probably fine.\n');


### PR DESCRIPTION
Adds a `--no-parent-folder` flag to the CLI. 

Using this flag removes the `<projectID/` prefix from file paths when unzipping, so all project code is dumped directly into the specified directory, instead of in a sub folder. 

To avoid breaking changes, the default for this flag is `--parent-folder`.

Test cases:
- default (`--parent-folder`) with `--dest` specified
- default (`--parent-folder`) with no destination specified
- `--no-parent-folder` with `--dest`
- `--no-parent-folder` with no destination specified
- All above cases with `--include-assets` applied
- All above cases with `--fix` applied