### PR TITLE
Add FLUTTERFLOW_PROJECT env variable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlutterFlow CLI
 
-FlutterFlow CLI client. Currently it only allows exporting code from FlutterFlow.
+FlutterFlow CLI client, download code 
 
 ## API Token
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlutterFlow CLI
 
-FlutterFlow CLI client, download code 
+FlutterFlow CLI client: download code from your FlutterFlow project to your device for local running or deployment.
 
 ## API Token
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ API access is available only to users with active subscriptions. Visit https://a
 
 `flutterflow export-code --project <project id> --dest <output folder> --[no-]include-assets --token <token> --[no-]fix --[no]-parent-folder`
 
-Alternatively, instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` environment variable.
+* Instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` environment variable.
+* Instead of passing `--project` you can set `FLUTTERFLOW_PROJECT` environment variable.
 
 ## Flags
 
 | Flag      | Abbreviation | Usage |
 | ----------- | ----------- | ----------- |
-| `--project`      | `-p`       | [Required] Project ID |
-| `--token`      | `-t`       | [Required or environment variable] API Token |
-| `--dest`   | `-d`        | [Optional] Output folder |
-| `--[no-]include-assets`   | None        | [Optional] Whether to include media assets. Defaults to `false` |
-| `--branch-name`   | `-b`        | [Optional] Which branch to download. Defaults to `main` |
+| `--project`      | `-p`       | [Required or environment variable] Project ID. |
+| `--token`      | `-t`       | [Required or environment variable] API Token. |
+| `--dest`   | `-d`        | [Optional] Output folder. Defaults to the current directory if none is specified. |
+| `--[no-]include-assets`   | None        | [Optional] Whether to include media assets. Defaults to `false`. |
+| `--branch-name`   | `-b`        | [Optional] Which branch to download. Defaults to `main`. |
 | `--[no-]fix`   | None        | [Optional] Whether to run `dart fix` on the downloaded code. Defaults to `false`. |
 | `--[no-]parent-folder`   | None        | [Optional] Whether to download code into a project-named sub-folder. If true, downloads all project files directly to the specified directory. Defaults to `true`. |
 

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -15,16 +15,25 @@ void main(List<String> args) async {
   final token =
       parsedArguments['token'] ?? Platform.environment['FLUTTERFLOW_API_TOKEN'];
 
+  final project =
+      parsedArguments['project'] ?? Platform.environment['FLUTTERFLOW_PROJECT'];
+
   if (token?.isEmpty ?? true) {
     stderr.write(
         'Either --token option or FLUTTERFLOW_API_TOKEN environment variable must be set.\n');
     exit(1);
   }
 
+  if (project?.isEmpty ?? true) {
+    stderr.write(
+        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
+    exit(1);
+  }
+
   await _exportCode(
     token: token,
     endpoint: parsedArguments['endpoint'] ?? kDefaultEndpoint,
-    projectId: parsedArguments.command!['project'],
+    projectId: project,
     destinationPath: parsedArguments.command!['dest'],
     includeAssets: parsedArguments.command!['include-assets'],
     branchName: parsedArguments.command!['branch-name'],
@@ -35,7 +44,6 @@ void main(List<String> args) async {
 
 ArgResults _parseArgs(List<String> args) {
   final exportCodeCommandParser = ArgParser()
-    ..addOption('project', abbr: 'p', help: 'Project id')
     ..addOption('dest',
         abbr: 'd', help: 'Destination directory', defaultsTo: '.')
     ..addOption('branch-name',
@@ -68,6 +76,7 @@ ArgResults _parseArgs(List<String> args) {
   final parser = ArgParser()
     ..addOption('endpoint', abbr: 'e', help: 'Endpoint', hide: true)
     ..addOption('token', abbr: 't', help: 'API Token')
+    ..addOption('project', abbr: 'p', help: 'Project id')
     ..addFlag('help', negatable: false, abbr: 'h', help: 'Help')
     ..addCommand('export-code', exportCodeCommandParser);
 
@@ -93,12 +102,6 @@ ArgResults _parseArgs(List<String> args) {
   if (parsed.command == null) {
     print(parser.usage);
     print('Available commands: ${parser.commands.keys.join(', ')}.');
-    exit(1);
-  }
-
-  if (parsed.command!['project'] == null ||
-      parsed.command!['project'].isEmpty) {
-    stderr.write('Option --project is required\n');
     exit(1);
   }
 

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -15,18 +15,12 @@ void main(List<String> args) async {
   final token =
       parsedArguments['token'] ?? Platform.environment['FLUTTERFLOW_API_TOKEN'];
 
-  final project =
-      parsedArguments['project'] ?? Platform.environment['FLUTTERFLOW_PROJECT'];
+  final project = parsedArguments.command!['project'] ??
+      Platform.environment['FLUTTERFLOW_PROJECT'];
 
   if (token?.isEmpty ?? true) {
     stderr.write(
         'Either --token option or FLUTTERFLOW_API_TOKEN environment variable must be set.\n');
-    exit(1);
-  }
-
-  if (project?.isEmpty ?? true) {
-    stderr.write(
-        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
     exit(1);
   }
 
@@ -44,6 +38,7 @@ void main(List<String> args) async {
 
 ArgResults _parseArgs(List<String> args) {
   final exportCodeCommandParser = ArgParser()
+    ..addOption('project', abbr: 'p', help: 'Project id')
     ..addOption('dest',
         abbr: 'd', help: 'Destination directory', defaultsTo: '.')
     ..addOption('branch-name',
@@ -76,7 +71,6 @@ ArgResults _parseArgs(List<String> args) {
   final parser = ArgParser()
     ..addOption('endpoint', abbr: 'e', help: 'Endpoint', hide: true)
     ..addOption('token', abbr: 't', help: 'API Token')
-    ..addOption('project', abbr: 'p', help: 'Project id')
     ..addFlag('help', negatable: false, abbr: 'h', help: 'Help')
     ..addCommand('export-code', exportCodeCommandParser);
 
@@ -105,6 +99,12 @@ ArgResults _parseArgs(List<String> args) {
     exit(1);
   }
 
+  if (parsed.command!['project'] == null ||
+      parsed.command!['project'].isEmpty) {
+    stderr.write(
+        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
+    exit(1);
+  }
   return parsed;
 }
 


### PR DESCRIPTION
Adds functionality for setting an environment variable for the `--project` flag.

Also adds some README cleanup.
