### PR TITLE
Add class docs and export the `flutterflow_cli_base`

### DIFF
--- a/lib/flutterflow_cli.dart
+++ b/lib/flutterflow_cli.dart
@@ -1,1 +1,3 @@
 library flutterflow_cli;
+
+export 'package:flutterflow_cli/src/flutterflow_cli_base.dart';

--- a/lib/src/flutterflow_cli_base.dart
+++ b/lib/src/flutterflow_cli_base.dart
@@ -7,7 +7,24 @@ import 'package:path/path.dart' as path_util;
 
 const kDefaultEndpoint = 'https://api.flutterflow.io/v1';
 
+/// The `FlutterFlowApi` class provides methods for exporting code from a
+/// FlutterFlow project.
 class FlutterFlowApi {
+  /// Exports the code from a FlutterFlow project.
+  ///
+  /// * [token] is the FlutterFlow API token for accessing the project.
+  /// * [projectId] is the ID of the project to export.
+  /// * [destinationPath] is the path where the exported code will be saved.
+  /// * [includeAssets] flag indicates whether to include project assets
+  /// in the export.
+  /// * [endpoint] is the API endpoint to use for exporting the code.
+  /// * [branchName] is the name of the branch to export from (optional).
+  /// * [unzipToParentFolder] flag indicates whether to unzip the exported code
+  /// to the parent folder.
+  /// * [fix] flag indicates whether to fix any issues in the exported code.
+  ///
+  /// Returns a [Future] that completes with the path to the exported code, or
+  /// `null` if the export fails.
   static Future<String?> export({
     required String token,
     required String projectId,

--- a/lib/src/flutterflow_cli_base.dart
+++ b/lib/src/flutterflow_cli_base.dart
@@ -24,7 +24,7 @@ class FlutterFlowApi {
   /// * [fix] flag indicates whether to fix any issues in the exported code.
   ///
   /// Returns a [Future] that completes with the path to the exported code, or
-  /// `null` if the export fails.
+  /// throws an error if the export fails.
   static Future<String?> export({
     required String token,
     required String projectId,


### PR DESCRIPTION
Add documentation for the `FlutterFlowApi` class, and export the `flutterflow_cli_base` inside `flutterflow_cli` for ease of use.