### PR TITLE
Remove duplicate archiving 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+## 0.0.9+1
+
+- Adds bug fix to duplicate archiving.
 ## 0.0.9
 
 - Add `--[no-]-parent option`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 0.0.9+1
 
 - Adds bug fix to duplicate archiving.
+
 ## 0.0.9
 
 - Add `--[no-]-parent option`.

--- a/lib/src/flutterflow_cli_base.dart
+++ b/lib/src/flutterflow_cli_base.dart
@@ -68,7 +68,6 @@ Future<String?> exportCode({
       projectId: projectId,
       branchName: branchName,
     );
-
     // Download actual code
     final projectZipBytes = base64Decode(result['project_zip']);
     final projectFolder = ZipDecoder().decodeBytes(projectZipBytes);
@@ -80,7 +79,6 @@ Future<String?> exportCode({
     }
 
     folderName = projectFolder.first.name;
-    extractArchiveToDisk(projectFolder, destinationPath);
 
     final postCodeGenerationFutures = <Future>[
       if (fix)
@@ -94,6 +92,7 @@ Future<String?> exportCode({
           client: client,
           destinationPath: destinationPath,
           assetDescriptions: result['assets'],
+          unzipToParentFolder: unzipToParentFolder,
         ),
     ];
 
@@ -181,9 +180,16 @@ Future _downloadAssets({
   required final http.Client client,
   required String destinationPath,
   required List<dynamic> assetDescriptions,
+  required unzipToParentFolder,
 }) async {
   final futures = assetDescriptions.map((assetDescription) async {
-    final path = assetDescription['path'];
+    String path = assetDescription['path'];
+
+    if (!unzipToParentFolder) {
+      path = path_util.joinAll(
+        path_util.split(path).sublist(1),
+      );
+    }
     final url = assetDescription['url'];
     final fileDest = path_util.join(destinationPath, path);
     try {


### PR DESCRIPTION
A bug was introduced in [PR](https://github.com/FlutterFlow/flutterflow-cli/commit/c25c1223d1b663feb2fd810275e01e3b5bd70b33) that caused code to be archived twice. This would only be noticed when using the `--no-parent-folder` flag, as it would cause code to be downloaded into the parent folder, and also in a sub folder. 

Another was introduced in the `downloadAssets` method, as it wasn't checking the `unzipToParentFolder` variable (variable introduced in [this commit](https://github.com/eilzo/flutterflow-cli/commit/bf3d4c814bea2c560d5f74447f0b5b31c4aa4697?diff=unified&w=0))