### PR TITLE
Fix `--fix` `--no-parent-folder` edge case

### DIFF
--- a/lib/src/flutterflow_cli_base.dart
+++ b/lib/src/flutterflow_cli_base.dart
@@ -218,6 +218,7 @@ Future _runFix({
     }
     final firstFilePath = projectFolder.files.first.name;
     final directory = path_util.split(firstFilePath).first;
+
     final workingDirectory = unzipToParentFolder
         ? path_util.join(destinationPath, directory)
         : destinationPath;

--- a/lib/src/flutterflow_cli_base.dart
+++ b/lib/src/flutterflow_cli_base.dart
@@ -218,7 +218,6 @@ Future _runFix({
     }
     final firstFilePath = projectFolder.files.first.name;
     final directory = path_util.split(firstFilePath).first;
-
     final workingDirectory = unzipToParentFolder
         ? path_util.join(destinationPath, directory)
         : destinationPath;
@@ -236,10 +235,10 @@ Future _runFix({
           '"flutter pub get" failed with code ${pubGetResult.exitCode}, stderr:\n${pubGetResult.stderr}\n');
       return;
     }
-
+    final fixDirectory = unzipToParentFolder ? directory : '';
     final dartFixResult = await Process.run(
       'dart',
-      ['fix', '--apply', directory],
+      ['fix', '--apply', fixDirectory],
       workingDirectory: destinationPath,
       runInShell: true,
       stdoutEncoding: utf8,


### PR DESCRIPTION
Edge case discovered where --fix would not work when --no-parent-folder and no --dest folder supplied. 

```
"dart fix" failed with code 64, stderr:
File doesn't exist: /Users/eilidhsouthren/flutterflow-cli/my_tn

Usage: dart fix [arguments]
-h, --help                      Print this usage information.
-n, --dry-run                   Preview the proposed changes but make no changes.
    --apply                     Apply the proposed changes.
    --code=<code1,code2,...>    Apply fixes for one (or more) diagnostic codes.

Run "dart help" to see global options.
```

Verified with `--dest`, `--no-parent-folder`, `--fix` test matrix.