### PR TITLE
Fix ProjectID environment variable issue

### DIFF
--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -14,6 +14,12 @@ void main(List<String> args) async {
   final project = parsedArguments.command!['project'] ??
       Platform.environment['FLUTTERFLOW_PROJECT'];
 
+  if (project == null) {
+    stderr.write(
+        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
+    exit(1);
+  }
+
   if (parsedArguments['endpoint'] != null &&
       parsedArguments['environment'] != null) {
     stderr.write(
@@ -113,11 +119,5 @@ ArgResults _parseArgs(List<String> args) {
     exit(1);
   }
 
-  if (parsed.command!['project'] == null ||
-      parsed.command!['project'].isEmpty) {
-    stderr.write(
-        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
-    exit(1);
-  }
   return parsed;
 }

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -14,7 +14,7 @@ void main(List<String> args) async {
   final project = parsedArguments.command!['project'] ??
       Platform.environment['FLUTTERFLOW_PROJECT'];
 
-  if (project == null) {
+  if (project == null || project.isEmpty) {
     stderr.write(
         'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
     exit(1);


### PR DESCRIPTION
**Problem**

Using on the environment variable `FLUTTERFLOW_PROJECT` wasn't sufficient to replace the `--project` flag. It would still throw a `"Either --project option or FLUTTERFLOW_PROJECT environment variable must be set"` error if the `FLUTTERFLOW_PROJECT` environment variable was set. 

**Cause**

The thrown error was only checking the non-empty/null status of the `--project` flag, rather than both the flag and optional env variable. 

**Test Cases**

Tested with combos of env variable alone, and env variable + -p flag (verified project flag overrides env variable if both are set)