### PR TITLE
[Bugfix] Prevent CLI from crashing while using `FlutterFlowApi`

### DIFF
--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:flutterflow_cli/src/flutterflow_cli_base.dart';
+import 'package:flutterflow_cli/src/flutterflow_api_client.dart';
 
 const kDefaultEndpoint = 'https://api.flutterflow.io/v1';
 
@@ -43,17 +43,21 @@ void main(List<String> args) async {
     endpoint = kDefaultEndpoint;
   }
 
-  await exportCode(
-    token: token,
-    endpoint: endpoint,
-    projectId: project,
-    destinationPath: parsedArguments.command!['dest'],
-    includeAssets: parsedArguments.command!['include-assets'],
-    branchName: parsedArguments.command!['branch-name'],
-    unzipToParentFolder: parsedArguments.command!['parent-folder'],
-    fix: parsedArguments.command!['fix'],
-    exportAsModule: parsedArguments.command!['as-module'],
-  );
+  try {
+    await exportCode(
+      token: token,
+      endpoint: endpoint,
+      projectId: project,
+      destinationPath: parsedArguments.command!['dest'],
+      includeAssets: parsedArguments.command!['include-assets'],
+      branchName: parsedArguments.command!['branch-name'],
+      unzipToParentFolder: parsedArguments.command!['parent-folder'],
+      fix: parsedArguments.command!['fix'],
+      exportAsModule: parsedArguments.command!['as-module'],
+    );
+  } catch (_) {
+    exit(1);
+  }
 }
 
 ArgResults _parseArgs(List<String> args) {

--- a/lib/flutterflow_cli.dart
+++ b/lib/flutterflow_cli.dart
@@ -1,3 +1,3 @@
 library flutterflow_cli;
 
-export 'package:flutterflow_cli/src/flutterflow_cli_base.dart';
+export 'package:flutterflow_cli/src/flutterflow_api_client.dart';

--- a/lib/src/flutterflow_cli_base.dart
+++ b/lib/src/flutterflow_cli_base.dart
@@ -46,6 +46,7 @@ class FlutterFlowApi {
         unzipToParentFolder: unzipToParentFolder,
         fix: fix,
         exportAsModule: exportAsModule,
+        isCli: false,
       );
 }
 
@@ -59,6 +60,7 @@ Future<String?> exportCode({
   required bool fix,
   required bool exportAsModule,
   String? branchName,
+  bool isCli = true,
 }) async {
   final endpointUrl = Uri.parse(endpoint);
   final client = http.Client();
@@ -71,6 +73,7 @@ Future<String?> exportCode({
       projectId: projectId,
       branchName: branchName,
       exportAsModule: exportAsModule,
+      isCli: isCli,
     );
     // Download actual code
     final projectZipBytes = base64Decode(result['project_zip']);
@@ -141,6 +144,7 @@ Future<dynamic> _callExport({
   required String projectId,
   String? branchName,
   required bool exportAsModule,
+  required bool isCli,
 }) async {
   final body = jsonEncode({
     'project': {
@@ -163,7 +167,7 @@ Future<dynamic> _callExport({
     stderr.write('Unexpected error from the server.\n');
     stderr.write('Status: ${response.statusCode}\n');
     stderr.write('Body: ${response.body}\n');
-    exit(1);
+    isCli ? exit(1) : throw 'Unexpected error from the server.';
   }
 
   final parsedResponse = jsonDecode(response.body);
@@ -175,7 +179,7 @@ Future<dynamic> _callExport({
     } else {
       stderr.write('Unexpected server error.\n');
     }
-    exit(1);
+    isCli ? exit(1) : throw 'Unexpected error from the server.';
   }
 
   return parsedResponse['value'];


### PR DESCRIPTION
`exit(1)` was causing the entire app to crash while exporting code using `FlutterFlowApi`. This uses `throw` instead of `exit(1)` when not being used in a CLI environment.