### PR TITLE
Endpoint envAdding Environment variable for FLUTTERFLOW_ENDPOINT

### DIFF
--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -14,6 +14,12 @@ void main(List<String> args) async {
   final project = parsedArguments.command!['project'] ??
       Platform.environment['FLUTTERFLOW_PROJECT'];
 
+  if (project == null) {
+    stderr.write(
+        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
+    exit(1);
+  }
+
   if (parsedArguments['endpoint'] != null &&
       parsedArguments['environment'] != null) {
     stderr.write(
@@ -113,11 +119,5 @@ ArgResults _parseArgs(List<String> args) {
     exit(1);
   }
 
-  if (parsed.command!['project'] == null ||
-      parsed.command!['project'].isEmpty) {
-    stderr.write(
-        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
-    exit(1);
-  }
   return parsed;
 }

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -14,7 +14,7 @@ void main(List<String> args) async {
   final project = parsedArguments.command!['project'] ??
       Platform.environment['FLUTTERFLOW_PROJECT'];
 
-  if (project == null) {
+  if (project == null || project.isEmpty) {
     stderr.write(
         'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
     exit(1);
@@ -43,16 +43,21 @@ void main(List<String> args) async {
     endpoint = Platform.environment['FLUTTERFLOW_ENDPOINT'] ?? kDefaultEndpoint;
   }
 
-  await exportCode(
-    token: token,
-    endpoint: endpoint,
-    projectId: project,
-    destinationPath: parsedArguments.command!['dest'],
-    includeAssets: parsedArguments.command!['include-assets'],
-    branchName: parsedArguments.command!['branch-name'],
-    unzipToParentFolder: parsedArguments.command!['parent-folder'],
-    fix: parsedArguments.command!['fix'],
-  );
+  try {
+    await exportCode(
+      token: token,
+      endpoint: endpoint,
+      projectId: project,
+      destinationPath: parsedArguments.command!['dest'],
+      includeAssets: parsedArguments.command!['include-assets'],
+      branchName: parsedArguments.command!['branch-name'],
+      unzipToParentFolder: parsedArguments.command!['parent-folder'],
+      fix: parsedArguments.command!['fix'],
+      exportAsModule: parsedArguments.command!['as-module'],
+    );
+  } catch (_) {
+    exit(1);
+  }
 }
 
 ArgResults _parseArgs(List<String> args) {

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -40,7 +40,7 @@ void main(List<String> args) async {
     endpoint =
         "https://api-${parsedArguments['environment']}.flutterflow.io/v1";
   } else {
-    endpoint = kDefaultEndpoint;
+    endpoint = Platform.environment['FLUTTERFLOW_ENDPOINT'] ?? kDefaultEndpoint;
   }
 
   await exportCode(


### PR DESCRIPTION
Allows the user to set the `--endpoint` flag as an environment variable, as the value is unlikely to change day-to-day. 

