### PR TITLE
Support export as debug for `FlutterFlowApi` 

### DIFF
--- a/lib/src/flutterflow_api_client.dart
+++ b/lib/src/flutterflow_api_client.dart
@@ -24,6 +24,8 @@ class FlutterFlowApi {
   /// * [fix] flag indicates whether to fix any issues in the exported code.
   /// * [exportAsModule] flag indicates whether to export the code as a module.
   /// * [format] flag indicates whether to format the exported code.
+  /// * [exportAsDebug] flag indicates whether to export the code as debug for
+  /// local run.
   ///
   /// Returns a [Future] that completes with the path to the exported code, or
   /// throws an error if the export fails.
@@ -38,6 +40,7 @@ class FlutterFlowApi {
     bool fix = false,
     bool exportAsModule = false,
     bool format = true,
+    bool exportAsDebug = false,
   }) =>
       exportCode(
         token: token,
@@ -50,6 +53,7 @@ class FlutterFlowApi {
         fix: fix,
         exportAsModule: exportAsModule,
         format: format,
+        exportAsDebug: exportAsDebug,
       );
 }
 
@@ -64,6 +68,7 @@ Future<String?> exportCode({
   required bool exportAsModule,
   bool format = true,
   String? branchName,
+  bool exportAsDebug = false,
 }) async {
   final endpointUrl = Uri.parse(endpoint);
   final client = http.Client();
@@ -78,6 +83,7 @@ Future<String?> exportCode({
       exportAsModule: exportAsModule,
       includeAssets: includeAssets,
       format: format,
+      exportAsDebug: exportAsDebug,
     );
     // Download actual code
     final projectZipBytes = base64Decode(result['project_zip']);
@@ -150,6 +156,7 @@ Future<dynamic> _callExport({
   required bool exportAsModule,
   required bool includeAssets,
   required bool format,
+  required bool exportAsDebug,
 }) async {
   final body = jsonEncode({
     'project': {
@@ -159,6 +166,7 @@ Future<dynamic> _callExport({
     'export_as_module': exportAsModule,
     'include_assets_map': includeAssets,
     'format': format,
+    'export_as_debug': exportAsDebug,
   });
   return await _callEndpoint(
     client: client,

--- a/lib/src/flutterflow_api_client.dart
+++ b/lib/src/flutterflow_api_client.dart
@@ -70,6 +70,9 @@ Future<String?> exportCode({
   String? branchName,
   bool exportAsDebug = false,
 }) async {
+  if (exportAsDebug && exportAsModule) {
+    throw 'Cannot export as module and debug at the same time.';
+  }
   final endpointUrl = Uri.parse(endpoint);
   final client = http.Client();
   String? folderName;


### PR DESCRIPTION
Add a new param inside the `exportCode` function of `FlutterFlowApi` to be able to download the code using debug logging.