### PR TITLE
Add .flutterflowignore support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           dart format . --set-exit-if-changed
 
-  build:
+  build_and_test:
     runs-on: ${{ matrix.os }}
     needs: check
     timeout-minutes: 10
@@ -60,3 +60,7 @@ jobs:
       - name: Run
         run: |
           dart run bin/flutterflow_cli.dart -h
+
+      - name: Test
+        run: |
+          dart test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,62 @@
+name: FlutterFlow
+on: push
+
+env:
+  # Keep this in sync with the version used by FlutterFlow.
+  DART_VERSION: 3.4.3
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ env.DART_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          dart pub get
+
+      - name: Analyze code
+        run: |
+          dart analyze
+
+      - name: Format code
+        run: |
+          dart format . --set-exit-if-changed
+
+  build:
+    runs-on: ${{ matrix.os }}
+    needs: check
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, windows-2022, macos-14]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ env.DART_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          dart pub get
+
+      - name: Build
+        run: |
+          dart compile exe bin/flutterflow_cli.dart
+
+      - name: Run
+        run: |
+          dart run bin/flutterflow_cli.dart -h

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ API access is available only to users with active subscriptions. Visit https://a
 * Instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` environment variable.
 * Instead of passing `--project` you can set `FLUTTERFLOW_PROJECT` environment variable.
 
+In case you are updating an existing project and you don't want existing files to be changed, you can create a `.flutterflowignore` file at the root of the output folder
+with a list of files to be ignored using [globbing syntax](https://pub.dev/packages/glob#syntax).
+
 ### Flags
 
 | Flag      | Abbreviation | Usage |

--- a/lib/src/flutterflow_api_client.dart
+++ b/lib/src/flutterflow_api_client.dart
@@ -5,6 +5,8 @@ import 'package:archive/archive_io.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as path_util;
 
+import 'flutterflow_ignore.dart';
+
 const kDefaultEndpoint = 'https://api.flutterflow.io/v1';
 
 /// The `FlutterFlowApi` class provides methods for exporting code from a
@@ -133,21 +135,26 @@ Future<String?> exportCode({
 // parent folder.
 void extractArchiveTo(
     Archive projectFolder, String destinationPath, bool unzipToParentFolder) {
+  final ignore = FlutterFlowIgnore(path: destinationPath);
+
   for (final file in projectFolder.files) {
     if (file.isFile) {
-      final data = file.content as List<int>;
-      final filename = file.name;
+      final relativeFilename =
+          path_util.joinAll(path_util.split(file.name).sublist(1));
+
+      // Found on .flutterflowignore, move on.
+      if (ignore.matches(unzipToParentFolder ? file.name : relativeFilename)) {
+        stderr.write('Ignoring $relativeFilename, file remained unchanged.\n');
+        continue;
+      }
 
       // Remove the `<project>` prefix from paths if needed.
       final path = path_util.join(
-          destinationPath,
-          unzipToParentFolder
-              ? filename
-              : path_util.joinAll(path_util.split(filename).sublist(1)));
+          destinationPath, unzipToParentFolder ? file.name : relativeFilename);
 
       final fileOut = File(path);
       fileOut.createSync(recursive: true);
-      fileOut.writeAsBytesSync(data);
+      fileOut.writeAsBytesSync(file.content as List<int>);
     }
   }
 }

--- a/lib/src/flutterflow_ignore.dart
+++ b/lib/src/flutterflow_ignore.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as path_util;
+
+final kIgnoreFile = '.flutterflowignore';
+
+class FlutterFlowIgnore {
+  final List<Glob> _globs = [];
+
+  FlutterFlowIgnore({path = '.'}) {
+    final String text;
+
+    try {
+      text = File(path_util.join(path, kIgnoreFile)).readAsStringSync();
+    } catch (e) {
+      return;
+    }
+
+    if (text.isEmpty) {
+      return;
+    }
+
+    final lines = LineSplitter().convert(text).map((line) {
+      return line.trim().replaceAll(RegExp(r'/$'), '/**');
+    });
+
+    for (var line in lines) {
+      if (line.isNotEmpty && !line.startsWith('#')) {
+        _globs.add(Glob(line));
+      }
+    }
+  }
+
+  bool matches(String path) {
+    return _globs.any((glob) => glob.matches(path));
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^3.0.0
+  test: ^1.25.8
 
 executables:
   flutterflow: flutterflow_cli

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   archive: ^3.3.5
   args: ^2.3.0
+  glob: ^2.1.0
   http: ^1.1.0
   path: ^1.8.0
 

--- a/test/fixtures/.flutterflowignore
+++ b/test/fixtures/.flutterflowignore
@@ -1,0 +1,14 @@
+file
+dir/*
+dir_recursive/**/file
+dir_recursive_implicit/
+this/file/exactly
+this/directory/
+
+#comment
+  #another_comment
+
+  LEADING_SPACES.md
+TRAILING_SPACES.md  
+  LEADING_AND_TRAILING_SPACES.md  
+

--- a/test/flutterflow_ignore_test.dart
+++ b/test/flutterflow_ignore_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutterflow_cli/src/flutterflow_ignore.dart';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('does not match when file is not found', () {
+    var ignore = FlutterFlowIgnore(path: '/this/path/is/wrong/');
+
+    expect(ignore.matches('file'), false);
+  });
+
+  test('basic globbing syntax', () {
+    var ignore = FlutterFlowIgnore(path: 'test/fixtures');
+
+    expect(ignore.matches('file'), true);
+    expect(ignore.matches('dir/foo'), true);
+    expect(ignore.matches('dir/bar'), true);
+    expect(ignore.matches('this/file/exactly'), true);
+
+    expect(ignore.matches('this/directory/matches'), true);
+    expect(ignore.matches('this/directory/also/matches'), true);
+
+    expect(ignore.matches('dir_recursive/foo/file'), true);
+    expect(ignore.matches('dir_recursive/foo/bar/file'), true);
+    expect(ignore.matches('dir_recursive/foo/bar/foo/file'), true);
+
+    expect(ignore.matches('dir_recursive_implicit/foo/file'), true);
+    expect(ignore.matches('dir_recursive_implicit/foo/bar/file'), true);
+    expect(ignore.matches('dir_recursive_implicit/foo/bar/foo/file'), true);
+
+    expect(ignore.matches('this/file'), false);
+    expect(ignore.matches('this/file/not_really'), false);
+    expect(ignore.matches('file/not_a_directory'), false);
+    expect(ignore.matches('file_not_found'), false);
+    expect(ignore.matches('dir_not_found/foo'), false);
+    expect(ignore.matches('dir_not_found/bar'), false);
+    expect(ignore.matches('this/directory'), false);
+
+    expect(ignore.matches('dir_recursive/foo/file_not_found'), false);
+    expect(ignore.matches('dir_recursive/foo/bar/file_not_found'), false);
+    expect(ignore.matches('dir_recursive/foo/bar/foo/file_not_found'), false);
+  });
+
+  test('comments are ignored', () {
+    var ignore = FlutterFlowIgnore(path: 'test/fixtures');
+
+    expect(ignore.matches('#comment'), false);
+    expect(ignore.matches('#another_comment'), false);
+  });
+
+  test('does not match empty paths', () {
+    var ignore = FlutterFlowIgnore(path: 'test/fixtures');
+
+    expect(ignore.matches(''), false);
+  });
+
+  test('ignores leading and trailing spaces', () {
+    var ignore = FlutterFlowIgnore(path: 'test/fixtures');
+
+    expect(ignore.matches('LEADING_SPACES.md'), true);
+    expect(ignore.matches('TRAILING_SPACES.md'), true);
+    expect(ignore.matches('LEADING_AND_TRAILING_SPACES.md'), true);
+  });
+}


### PR DESCRIPTION
This file allows for users to create a list of files to be ignored when exporting the project code (works a bit like .gitignore).

Files matching the globbing rules listed at .flutterflowignore are going to be ignored. This might break the project if changes in these files are needed to compile the project, so it should be used with extreme caution.

This functionality was previously achieved with:
https://github.com/krabhishek/flutterflow-filtered-pull