### PR TITLE
Add export manifest flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.0.31
 
 - Add `--include-export-manifest` to `flutterflow export-code` and forward `includeExportManifest` to the export API so the downloaded archive can include `.flutterflow/export_manifest.json`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add `--include-export-manifest` to `flutterflow export-code` and forward `includeExportManifest` to the export API so the downloaded archive can include `.flutterflow/export_manifest.json`.
+
 ## 0.0.30
 
 - Occasionally suggest using `--fix` flag when it's not passed.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ API access is available only to users with active subscriptions. Visit https://a
 
 ### Usage
 
-`flutterflow export-code --project <project id> --dest <output folder> --[no-]include-assets --token <token> --[no-]fix --[no-]parent-folder --[no-]as-module --[no-]as-debug`
+`flutterflow export-code --project <project id> --dest <output folder> --[no-]include-assets --token <token> --[no-]fix --[no-]parent-folder --[no-]as-module --[no-]as-debug --[no-]include-export-manifest`
 
 * Instead of passing `--token` you can set `FLUTTERFLOW_API_TOKEN` environment variable.
 * Instead of passing `--project` you can set `FLUTTERFLOW_PROJECT` environment variable.
@@ -30,6 +30,7 @@ with a list of files to be ignored using [globbing syntax](https://pub.dev/packa
 | `--token`      | `-t`       | [Required or environment variable] API Token. |
 | `--dest`   | `-d`        | [Optional] Output folder. Defaults to the current directory if none is specified. |
 | `--[no-]include-assets`   | None        | [Optional] Whether to include media assets. Defaults to `false`. |
+| `--[no-]include-export-manifest`   | None        | [Optional] Whether to include `.flutterflow/export_manifest.json` so tools can map FlutterFlow entities to generated files. Defaults to `false`. |
 | `--branch-name`   | `-b`        | [Optional] Which branch to download. Defaults to `main`. |
 | `--[no-]fix`   | None        | [Optional] Whether to run `dart fix` on the downloaded code. Defaults to `false`. |
 | `--[no-]parent-folder`   | None        | [Optional] Whether to download code into a project-named sub-folder. If true, downloads all project files directly to the specified directory. Defaults to `true`. |

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -12,25 +12,29 @@ Future<void> appMain(List<String> args) async {
   final token =
       parsedArguments['token'] ?? Platform.environment['FLUTTERFLOW_API_TOKEN'];
 
-  final project = parsedArguments.command!['project'] ??
+  final project =
+      parsedArguments.command!['project'] ??
       Platform.environment['FLUTTERFLOW_PROJECT'];
 
   if (project == null || project.isEmpty) {
     stderr.write(
-        'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n');
+      'Either --project option or FLUTTERFLOW_PROJECT environment variable must be set.\n',
+    );
     exit(1);
   }
 
   if (parsedArguments['endpoint'] != null &&
       parsedArguments['environment'] != null) {
     stderr.write(
-        'Only one of --endpoint and --environment options can be set.\n');
+      'Only one of --endpoint and --environment options can be set.\n',
+    );
     exit(1);
   }
 
   if (token?.isEmpty ?? true) {
     stderr.write(
-        'Either --token option or FLUTTERFLOW_API_TOKEN environment variable must be set.\n');
+      'Either --token option or FLUTTERFLOW_API_TOKEN environment variable must be set.\n',
+    );
     exit(1);
   }
 
@@ -60,6 +64,8 @@ Future<void> appMain(List<String> args) async {
           exportAsModule: parsedArguments.command!['as-module'],
           exportAsDebug: parsedArguments.command!['as-debug'],
           environmentName: parsedArguments.command!['project-environment'],
+          includeExportManifest:
+              parsedArguments.command!['include-export-manifest'],
         );
         if (!parsedArguments.command!['fix'] && Random().nextDouble() < 0.2) {
           print(
@@ -87,82 +93,96 @@ Future<void> appMain(List<String> args) async {
 }
 
 ArgResults _parseArgs(List<String> args) {
-  final exportCodeCommandParser = ArgParser()
-    ..addOption('project', abbr: 'p', help: 'Project id')
-    ..addOption(
-      'dest',
-      abbr: 'd',
-      help: 'Destination directory',
-      defaultsTo: '.',
-    )
-    ..addOption(
-      'branch-name',
-      abbr: 'b',
-      help: '(Optional) Specify a branch name',
-    )
-    ..addOption(
-      'commit-hash',
-      abbr: 'c',
-      help: '(Optional) Specify a commit hash',
-    )
-    ..addFlag(
-      'include-assets',
-      negatable: true,
-      help: 'Include assets. By default, assets are not included.\n'
-          'We recommend setting this flag only when calling this command '
-          'for the first time or after updating assets.\n'
-          'Downloading code without assets is typically much faster.',
-      defaultsTo: false,
-    )
-    ..addFlag(
-      'fix',
-      negatable: true,
-      help: 'Run "dart fix" on the downloaded code.',
-      defaultsTo: false,
-    )
-    ..addFlag(
-      'parent-folder',
-      negatable: true,
-      help: 'Download into a sub-folder. By default, project is downloaded \n'
-          'into a folder named <project>.\nSetting this flag to false will '
-          'download all project code directly into the specified directory, '
-          'or the current directory if --dest is not set.',
-      defaultsTo: true,
-    )
-    ..addFlag(
-      'as-module',
-      negatable: true,
-      help: 'Generate the project as a Flutter module.',
-      defaultsTo: false,
-    )
-    ..addFlag(
-      'as-debug',
-      negatable: true,
-      help: 'Generate the project with debug logging to be able to use '
-          'FlutterFlow Debug Panel inside the DevTools.',
-      defaultsTo: false,
-    )
-    ..addOption(
-      'project-environment',
-      help: '(Optional) Specify a project environment name.',
-    );
+  final exportCodeCommandParser =
+      ArgParser()
+        ..addOption('project', abbr: 'p', help: 'Project id')
+        ..addOption(
+          'dest',
+          abbr: 'd',
+          help: 'Destination directory',
+          defaultsTo: '.',
+        )
+        ..addOption(
+          'branch-name',
+          abbr: 'b',
+          help: '(Optional) Specify a branch name',
+        )
+        ..addOption(
+          'commit-hash',
+          abbr: 'c',
+          help: '(Optional) Specify a commit hash',
+        )
+        ..addFlag(
+          'include-assets',
+          negatable: true,
+          help:
+              'Include assets. By default, assets are not included.\n'
+              'We recommend setting this flag only when calling this command '
+              'for the first time or after updating assets.\n'
+              'Downloading code without assets is typically much faster.',
+          defaultsTo: false,
+        )
+        ..addFlag(
+          'include-export-manifest',
+          negatable: true,
+          help:
+              'Request .flutterflow/export_manifest.json in the downloaded '
+              'export so tools can map FlutterFlow entities to generated files.',
+          defaultsTo: false,
+        )
+        ..addFlag(
+          'fix',
+          negatable: true,
+          help: 'Run "dart fix" on the downloaded code.',
+          defaultsTo: false,
+        )
+        ..addFlag(
+          'parent-folder',
+          negatable: true,
+          help:
+              'Download into a sub-folder. By default, project is downloaded \n'
+              'into a folder named <project>.\nSetting this flag to false will '
+              'download all project code directly into the specified directory, '
+              'or the current directory if --dest is not set.',
+          defaultsTo: true,
+        )
+        ..addFlag(
+          'as-module',
+          negatable: true,
+          help: 'Generate the project as a Flutter module.',
+          defaultsTo: false,
+        )
+        ..addFlag(
+          'as-debug',
+          negatable: true,
+          help:
+              'Generate the project with debug logging to be able to use '
+              'FlutterFlow Debug Panel inside the DevTools.',
+          defaultsTo: false,
+        )
+        ..addOption(
+          'project-environment',
+          help: '(Optional) Specify a project environment name.',
+        );
 
-  final firebaseDeployCommandParser = ArgParser()
-    ..addOption('project', abbr: 'p', help: 'Project id')
-    ..addFlag(
-      'append-rules',
-      abbr: 'a',
-      help: 'Append to rules, instead of overwriting them.',
-      defaultsTo: false,
-    );
+  final firebaseDeployCommandParser =
+      ArgParser()
+        ..addOption('project', abbr: 'p', help: 'Project id')
+        ..addFlag(
+          'append-rules',
+          abbr: 'a',
+          help: 'Append to rules, instead of overwriting them.',
+          defaultsTo: false,
+        );
 
-  final parser = ArgParser()
-    ..addOption('endpoint', abbr: 'e', help: 'Endpoint', hide: true)
-    ..addOption('environment', help: 'Environment', hide: true)
-    ..addOption('token', abbr: 't', help: 'API Token')
-    ..addFlag('help', negatable: false, abbr: 'h', help: 'Help')
-    ..addCommand('export-code', exportCodeCommandParser)
-    ..addCommand('deploy-firebase', firebaseDeployCommandParser);
+  final parser =
+      ArgParser()
+        ..addOption('endpoint', abbr: 'e', help: 'Endpoint', hide: true)
+        ..addOption('environment', help: 'Environment', hide: true)
+        ..addOption('token', abbr: 't', help: 'API Token')
+        ..addFlag('help', negatable: false, abbr: 'h', help: 'Help')
+        ..addCommand('export-code', exportCodeCommandParser)
+        ..addCommand('deploy-firebase', firebaseDeployCommandParser);
 
   late ArgResults parsed;
   try {

--- a/bin/flutterflow_cli.dart
+++ b/bin/flutterflow_cli.dart
@@ -12,8 +12,7 @@ Future<void> appMain(List<String> args) async {
   final token =
       parsedArguments['token'] ?? Platform.environment['FLUTTERFLOW_API_TOKEN'];
 
-  final project =
-      parsedArguments.command!['project'] ??
+  final project = parsedArguments.command!['project'] ??
       Platform.environment['FLUTTERFLOW_PROJECT'];
 
   if (project == null || project.isEmpty) {
@@ -93,96 +92,89 @@ Future<void> appMain(List<String> args) async {
 }
 
 ArgResults _parseArgs(List<String> args) {
-  final exportCodeCommandParser =
-      ArgParser()
-        ..addOption('project', abbr: 'p', help: 'Project id')
-        ..addOption(
-          'dest',
-          abbr: 'd',
-          help: 'Destination directory',
-          defaultsTo: '.',
-        )
-        ..addOption(
-          'branch-name',
-          abbr: 'b',
-          help: '(Optional) Specify a branch name',
-        )
-        ..addOption(
-          'commit-hash',
-          abbr: 'c',
-          help: '(Optional) Specify a commit hash',
-        )
-        ..addFlag(
-          'include-assets',
-          negatable: true,
-          help:
-              'Include assets. By default, assets are not included.\n'
-              'We recommend setting this flag only when calling this command '
-              'for the first time or after updating assets.\n'
-              'Downloading code without assets is typically much faster.',
-          defaultsTo: false,
-        )
-        ..addFlag(
-          'include-export-manifest',
-          negatable: true,
-          help:
-              'Request .flutterflow/export_manifest.json in the downloaded '
-              'export so tools can map FlutterFlow entities to generated files.',
-          defaultsTo: false,
-        )
-        ..addFlag(
-          'fix',
-          negatable: true,
-          help: 'Run "dart fix" on the downloaded code.',
-          defaultsTo: false,
-        )
-        ..addFlag(
-          'parent-folder',
-          negatable: true,
-          help:
-              'Download into a sub-folder. By default, project is downloaded \n'
-              'into a folder named <project>.\nSetting this flag to false will '
-              'download all project code directly into the specified directory, '
-              'or the current directory if --dest is not set.',
-          defaultsTo: true,
-        )
-        ..addFlag(
-          'as-module',
-          negatable: true,
-          help: 'Generate the project as a Flutter module.',
-          defaultsTo: false,
-        )
-        ..addFlag(
-          'as-debug',
-          negatable: true,
-          help:
-              'Generate the project with debug logging to be able to use '
-              'FlutterFlow Debug Panel inside the DevTools.',
-          defaultsTo: false,
-        )
-        ..addOption(
-          'project-environment',
-          help: '(Optional) Specify a project environment name.',
-        );
+  final exportCodeCommandParser = ArgParser()
+    ..addOption('project', abbr: 'p', help: 'Project id')
+    ..addOption(
+      'dest',
+      abbr: 'd',
+      help: 'Destination directory',
+      defaultsTo: '.',
+    )
+    ..addOption(
+      'branch-name',
+      abbr: 'b',
+      help: '(Optional) Specify a branch name',
+    )
+    ..addOption(
+      'commit-hash',
+      abbr: 'c',
+      help: '(Optional) Specify a commit hash',
+    )
+    ..addFlag(
+      'include-assets',
+      negatable: true,
+      help: 'Include assets. By default, assets are not included.\n'
+          'We recommend setting this flag only when calling this command '
+          'for the first time or after updating assets.\n'
+          'Downloading code without assets is typically much faster.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'include-export-manifest',
+      negatable: true,
+      help: 'Request .flutterflow/export_manifest.json in the downloaded '
+          'export so tools can map FlutterFlow entities to generated files.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'fix',
+      negatable: true,
+      help: 'Run "dart fix" on the downloaded code.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'parent-folder',
+      negatable: true,
+      help: 'Download into a sub-folder. By default, project is downloaded \n'
+          'into a folder named <project>.\nSetting this flag to false will '
+          'download all project code directly into the specified directory, '
+          'or the current directory if --dest is not set.',
+      defaultsTo: true,
+    )
+    ..addFlag(
+      'as-module',
+      negatable: true,
+      help: 'Generate the project as a Flutter module.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'as-debug',
+      negatable: true,
+      help: 'Generate the project with debug logging to be able to use '
+          'FlutterFlow Debug Panel inside the DevTools.',
+      defaultsTo: false,
+    )
+    ..addOption(
+      'project-environment',
+      help: '(Optional) Specify a project environment name.',
+    );
 
-  final firebaseDeployCommandParser =
-      ArgParser()
-        ..addOption('project', abbr: 'p', help: 'Project id')
-        ..addFlag(
-          'append-rules',
-          abbr: 'a',
-          help: 'Append to rules, instead of overwriting them.',
-          defaultsTo: false,
-        );
+  final firebaseDeployCommandParser = ArgParser()
+    ..addOption('project', abbr: 'p', help: 'Project id')
+    ..addFlag(
+      'append-rules',
+      abbr: 'a',
+      help: 'Append to rules, instead of overwriting them.',
+      defaultsTo: false,
+    );
 
-  final parser =
-      ArgParser()
-        ..addOption('endpoint', abbr: 'e', help: 'Endpoint', hide: true)
-        ..addOption('environment', help: 'Environment', hide: true)
-        ..addOption('token', abbr: 't', help: 'API Token')
-        ..addFlag('help', negatable: false, abbr: 'h', help: 'Help')
-        ..addCommand('export-code', exportCodeCommandParser)
-        ..addCommand('deploy-firebase', firebaseDeployCommandParser);
+  final parser = ArgParser()
+    ..addOption('endpoint', abbr: 'e', help: 'Endpoint', hide: true)
+    ..addOption('environment', help: 'Environment', hide: true)
+    ..addOption('token', abbr: 't', help: 'API Token')
+    ..addFlag('help', negatable: false, abbr: 'h', help: 'Help')
+    ..addCommand('export-code', exportCodeCommandParser)
+    ..addCommand('deploy-firebase', firebaseDeployCommandParser);
 
   late ArgResults parsed;
   try {

--- a/lib/src/flutterflow_api_client.dart
+++ b/lib/src/flutterflow_api_client.dart
@@ -29,6 +29,8 @@ class FlutterFlowApi {
   /// * [exportAsDebug] flag indicates whether to export the code as debug for
   /// local run.
   /// * [environmentName] is the name of the environment to export the code for.
+  /// * [includeExportManifest] flag indicates whether to include
+  /// `.flutterflow/export_manifest.json` in the export archive.
   ///
   /// Returns a [Future] that completes with the path to the exported code, or
   /// throws an error if the export fails.
@@ -46,21 +48,22 @@ class FlutterFlowApi {
     bool exportAsModule = false,
     bool format = true,
     bool exportAsDebug = false,
-  }) =>
-      exportCode(
-        token: token,
-        endpoint: endpoint,
-        projectId: projectId,
-        destinationPath: destinationPath,
-        includeAssets: includeAssets,
-        branchName: branchName,
-        commitHash: commitHash,
-        unzipToParentFolder: unzipToParentFolder,
-        fix: fix,
-        exportAsModule: exportAsModule,
-        format: format,
-        exportAsDebug: exportAsDebug,
-      );
+    bool includeExportManifest = false,
+  }) => exportCode(
+    token: token,
+    endpoint: endpoint,
+    projectId: projectId,
+    destinationPath: destinationPath,
+    includeAssets: includeAssets,
+    branchName: branchName,
+    commitHash: commitHash,
+    unzipToParentFolder: unzipToParentFolder,
+    fix: fix,
+    exportAsModule: exportAsModule,
+    format: format,
+    exportAsDebug: exportAsDebug,
+    includeExportManifest: includeExportManifest,
+  );
 }
 
 Future<String?> exportCode({
@@ -77,11 +80,13 @@ Future<String?> exportCode({
   String? environmentName,
   String? commitHash,
   bool exportAsDebug = false,
+  bool includeExportManifest = false,
 }) async {
   stderr.write('Downloading code with the FlutterFlow CLI...\n');
   stderr.write('You are exporting project $projectId.\n');
   stderr.write(
-      '${branchName != null ? 'Branch: $branchName ' : ''}${environmentName != null ? 'Environment: $environmentName ' : ''}${commitHash != null ? 'Commit: $commitHash' : ''}\n');
+    '${branchName != null ? 'Branch: $branchName ' : ''}${environmentName != null ? 'Environment: $environmentName ' : ''}${commitHash != null ? 'Commit: $commitHash' : ''}\n',
+  );
   if (exportAsDebug && exportAsModule) {
     throw 'Cannot export as module and debug at the same time.';
   }
@@ -101,6 +106,7 @@ Future<String?> exportCode({
       includeAssets: includeAssets,
       format: format,
       exportAsDebug: exportAsDebug,
+      includeExportManifest: includeExportManifest,
     );
     // Download actual code
     final List<int> projectZipBytes;
@@ -149,13 +155,17 @@ Future<String?> exportCode({
 // Extract files to the specified directory without a project-named
 // parent folder.
 void extractArchiveTo(
-    Archive projectFolder, String destinationPath, bool unzipToParentFolder) {
+  Archive projectFolder,
+  String destinationPath,
+  bool unzipToParentFolder,
+) {
   final ignore = FlutterFlowIgnore(path: destinationPath);
 
   for (final file in projectFolder.files) {
     if (file.isFile) {
-      final relativeFilename =
-          path_util.joinAll(path_util.split(file.name).sublist(1));
+      final relativeFilename = path_util.joinAll(
+        path_util.split(file.name).sublist(1),
+      );
 
       // Found on .flutterflowignore, move on.
       if (ignore.matches(unzipToParentFolder ? file.name : relativeFilename)) {
@@ -165,7 +175,9 @@ void extractArchiveTo(
 
       // Remove the `<project>` prefix from paths if needed.
       final path = path_util.join(
-          destinationPath, unzipToParentFolder ? file.name : relativeFilename);
+        destinationPath,
+        unzipToParentFolder ? file.name : relativeFilename,
+      );
 
       final fileOut = File(path);
       fileOut.createSync(recursive: true);
@@ -186,6 +198,7 @@ Future<dynamic> _callExport({
   required bool includeAssets,
   required bool format,
   required bool exportAsDebug,
+  required bool includeExportManifest,
 }) async {
   final body = jsonEncode({
     'project_id': projectId,
@@ -196,6 +209,7 @@ Future<dynamic> _callExport({
     'include_assets_map': includeAssets,
     'format': format,
     'export_as_debug': exportAsDebug,
+    'includeExportManifest': includeExportManifest,
   });
   return await _callEndpoint(
     client: client,
@@ -258,9 +272,7 @@ Future _downloadAssets({
     String path = assetDescription['path'];
 
     if (!unzipToParentFolder) {
-      path = path_util.joinAll(
-        path_util.split(path).sublist(1),
-      );
+      path = path_util.joinAll(path_util.split(path).sublist(1));
     }
     final url = assetDescription['url'];
     final fileDest = path_util.join(destinationPath, path);
@@ -293,9 +305,10 @@ Future _runFix({
     final firstFilePath = projectFolder.files.first.name;
     final directory = path_util.split(firstFilePath).first;
 
-    final workingDirectory = unzipToParentFolder
-        ? path_util.join(destinationPath, directory)
-        : destinationPath;
+    final workingDirectory =
+        unzipToParentFolder
+            ? path_util.join(destinationPath, directory)
+            : destinationPath;
     stderr.write('Running flutter pub get...\n');
     final pubGetResult = await Process.run(
       'flutter',
@@ -307,7 +320,8 @@ Future _runFix({
     );
     if (pubGetResult.exitCode != 0) {
       stderr.write(
-          '"flutter pub get" failed with code ${pubGetResult.exitCode}, stderr:\n${pubGetResult.stderr}\n');
+        '"flutter pub get" failed with code ${pubGetResult.exitCode}, stderr:\n${pubGetResult.stderr}\n',
+      );
       return;
     }
     stderr.write('Running dart fix...\n');
@@ -322,7 +336,8 @@ Future _runFix({
     );
     if (dartFixResult.exitCode != 0) {
       stderr.write(
-          '"dart fix" failed with code ${dartFixResult.exitCode}, stderr:\n${dartFixResult.stderr}\n');
+        '"dart fix" failed with code ${dartFixResult.exitCode}, stderr:\n${dartFixResult.stderr}\n',
+      );
     }
   } catch (e) {
     stderr.write('Error running "dart fix": $e\n');
@@ -344,7 +359,9 @@ Future firebaseDeploy({
     client: http.Client(),
     token: token,
     url: Uri.https(
-        endpointUrl.host, '${endpointUrl.path}/exportFirebaseDeployCode'),
+      endpointUrl.host,
+      '${endpointUrl.path}/exportFirebaseDeployCode',
+    ),
     body: body,
   );
 
@@ -355,8 +372,9 @@ Future firebaseDeploy({
   Directory? tmpFolder;
 
   try {
-    tmpFolder =
-        Directory.systemTemp.createTempSync('${projectId}_$firebaseProjectId');
+    tmpFolder = Directory.systemTemp.createTempSync(
+      '${projectId}_$firebaseProjectId',
+    );
     extractArchiveTo(projectFolder, tmpFolder.path, false);
     final firebaseDir = '${tmpFolder.path}/firebase';
 

--- a/lib/src/flutterflow_api_client.dart
+++ b/lib/src/flutterflow_api_client.dart
@@ -49,21 +49,22 @@ class FlutterFlowApi {
     bool format = true,
     bool exportAsDebug = false,
     bool includeExportManifest = false,
-  }) => exportCode(
-    token: token,
-    endpoint: endpoint,
-    projectId: projectId,
-    destinationPath: destinationPath,
-    includeAssets: includeAssets,
-    branchName: branchName,
-    commitHash: commitHash,
-    unzipToParentFolder: unzipToParentFolder,
-    fix: fix,
-    exportAsModule: exportAsModule,
-    format: format,
-    exportAsDebug: exportAsDebug,
-    includeExportManifest: includeExportManifest,
-  );
+  }) =>
+      exportCode(
+        token: token,
+        endpoint: endpoint,
+        projectId: projectId,
+        destinationPath: destinationPath,
+        includeAssets: includeAssets,
+        branchName: branchName,
+        commitHash: commitHash,
+        unzipToParentFolder: unzipToParentFolder,
+        fix: fix,
+        exportAsModule: exportAsModule,
+        format: format,
+        exportAsDebug: exportAsDebug,
+        includeExportManifest: includeExportManifest,
+      );
 }
 
 Future<String?> exportCode({
@@ -305,10 +306,9 @@ Future _runFix({
     final firstFilePath = projectFolder.files.first.name;
     final directory = path_util.split(firstFilePath).first;
 
-    final workingDirectory =
-        unzipToParentFolder
-            ? path_util.join(destinationPath, directory)
-            : destinationPath;
+    final workingDirectory = unzipToParentFolder
+        ? path_util.join(destinationPath, directory)
+        : destinationPath;
     stderr.write('Running flutter pub get...\n');
     final pubGetResult = await Process.run(
       'flutter',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutterflow_cli
 description: >-
   Command-line client for FlutterFlow. Export code from FlutterFlow projects.
-version: 0.0.30
+version: 0.0.31
 homepage: https://github.com/FlutterFlow/flutterflow-cli
 issue_tracker: https://github.com/flutterflow/flutterflow-issues
 

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -9,8 +9,12 @@ String kProjectId = 'app-with-assets-and-custom-fonts-qxwg6o';
 String kToken = Platform.environment['FF_TESTER_TOKEN'] ?? 'not-set';
 
 Future<bool> buildProject(String project) async {
-  var result = await Process.run('flutter', ['build', 'web'],
-      workingDirectory: p.normalize(project), runInShell: true);
+  var result = await Process.run(
+    'flutter',
+    ['build', 'web'],
+    workingDirectory: p.normalize(project),
+    runInShell: true,
+  );
 
   if (result.exitCode != 0) {
     stderr.writeln(result.stderr);
@@ -108,9 +112,12 @@ void main() {
 
       // Fix will add 'const' to a lot of stuff :-)
       expect(
-          fileContains(
-              '$project/lib/main.dart', 'localizationsDelegates: const ['),
-          true);
+        fileContains(
+          '$project/lib/main.dart',
+          'localizationsDelegates: const [',
+        ),
+        true,
+      );
 
       expect(checkAssets(project), true);
 
@@ -136,9 +143,11 @@ void main() {
       ]);
 
       expect(
-          fileExists(
-              '$project/lib/pages/page_only_on_this_branch/page_only_on_this_branch_widget.dart'),
-          true);
+        fileExists(
+          '$project/lib/pages/page_only_on_this_branch/page_only_on_this_branch_widget.dart',
+        ),
+        true,
+      );
 
       expect(checkAssets(project), true);
 
@@ -164,9 +173,11 @@ void main() {
       ]);
 
       expect(
-          fileExists(
-              '$project/lib/pages/page_only_on_this_commit/page_only_on_this_commit_widget.dart'),
-          true);
+        fileExists(
+          '$project/lib/pages/page_only_on_this_commit/page_only_on_this_commit_widget.dart',
+        ),
+        true,
+      );
 
       expect(checkAssets(project), true);
 
@@ -191,8 +202,10 @@ void main() {
       ]);
 
       // Debug instrumentation added by the flag
-      expect(fileContains('$project/lib/main.dart', 'debugLogGlobalProperty'),
-          true);
+      expect(
+        fileContains('$project/lib/main.dart', 'debugLogGlobalProperty'),
+        true,
+      );
 
       expect(checkAssets(project), true);
 
@@ -242,14 +255,35 @@ void main() {
       ]);
 
       expect(
-          fileContains('$project/assets/environment_values/environment.json',
-              '"foobar": "barfoo"'),
-          true);
+        fileContains(
+          '$project/assets/environment_values/environment.json',
+          '"foobar": "barfoo"',
+        ),
+        true,
+      );
 
       expect(checkAssets(project), true);
 
       final buildResult = await buildProject(project);
       expect(buildResult, true);
+    });
+
+    test('export manifest', () async {
+      final project = 'export/export_manifest';
+
+      await appMain([
+        'export-code',
+        '--no-parent-folder',
+        '--project',
+        kProjectId,
+        '--token',
+        kToken,
+        '-d',
+        p.normalize(project),
+        '--include-export-manifest',
+      ]);
+
+      expect(fileExists('$project/.flutterflow/export_manifest.json'), true);
     });
   }, timeout: Timeout(Duration(minutes: 30)));
 }


### PR DESCRIPTION
## Summary
- add `--include-export-manifest` to `flutterflow export-code`
- send `includeExportManifest` in the export request body
- bump the package to `0.0.31` and document the new flag

## Testing
- dart analyze
- dart test test/flutterflow_ignore_test.dart
